### PR TITLE
Add healer to cleric check

### DIFF
--- a/src/components/cards/more-info/team-checklist.js
+++ b/src/components/cards/more-info/team-checklist.js
@@ -44,7 +44,13 @@ class TeamChecklist extends React.Component {
         ]) || this.hasWishAndProtect(),
       },
       'Defensive': {
-        'Cleric': store.doesTeamHaveMoves(['aromatherapy', 'healbell']), 
+        'Cleric/Healer': store.doesTeamHaveMoves([
+	  'aromatherapy',
+	  'healbell',
+	  'wish',
+	  'healingwish',
+	  'lunardance',
+	]), 
         'Status Move': store.anyStatusMoves, 
         'Phazer': store.doesTeamHaveMoves([
           'circlethrow',


### PR DESCRIPTION
I did this because heal bell and aroma therapy are no longer available in gen 9. Instead, I added the role healer to the cleric check, which looks for moves that can heal team mates. I hope I did not forget any. This assumes singles.